### PR TITLE
Use tilde heredoc syntax instead

### DIFF
--- a/stripe-mock.rb
+++ b/stripe-mock.rb
@@ -11,7 +11,7 @@ class StripeMock < Formula
 
   plist_options :startup => false
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">


### PR DESCRIPTION
Homebrew is not giving us this warning:

``` sh
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/stripe/homebrew-stripe-mock/stripe-mock.rb:43:in `plist'
Please report this to the stripe/stripe-mock tap!
```

This patch fixes it by moving us over to the new heredoc tilde syntax that
accomplishes the same thing as `#undent` (stripping leading whitespace).