### PR TITLE
spelling error in URL

### DIFF
--- a/stripe-mock.rb
+++ b/stripe-mock.rb
@@ -1,6 +1,6 @@
 class StripeMock < Formula
   desc "stripe-mock is a mock HTTP server that responds like the real Stripe API. It can be used instead of Stripe's testmode to make test suites integrating with Stripe faster and less brittle."
-  homepage "https://github.com.com/stripe/stripe-mock"
+  homepage "https://github.com/stripe/stripe-mock"
   url "https://github.com/stripe/stripe-mock/releases/download/v0.7.0/stripe-mock_0.7.0_darwin_amd64.tar.gz"
   version "0.7.0"
   sha256 "3fa9e7076f3a436670464e94048e60655397340927e50825d36bb06616343378"


### PR DESCRIPTION
URL had .com.com instead of just .com