### PR TITLE
Listen for HTTP and HTTPS simultaneously

### DIFF
--- a/stripe-mock.rb
+++ b/stripe-mock.rb
@@ -26,8 +26,10 @@ class StripeMock < Formula
     <key>ProgramArguments</key>
     <array>
       <string>#{opt_bin}/stripe-mock</string>
-      <string>-port</string>
+      <string>-http-port</string>
       <string>12111</string>
+      <string>-https-port</string>
+      <string>12112</string>
     </array>
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
See stripe/stripe-mock#84 for full context, but once that's merged, here
we start listening for both HTTP and HTTPS simultaneously so that we can
test locally with API libraries that use either.

r? @ob-stripe
cc @stripe/api-libraries