### PR TITLE
Fix release

### DIFF
--- a/stripe-mock.rb
+++ b/stripe-mock.rb
@@ -11,7 +11,7 @@ class StripeMock < Formula
 
   plist_options :startup => false
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -42,10 +42,6 @@ class StripeMock < Formula
   </dict>
 </plist>
 
-    EOS
-  end
-
-  test do
-    
+  EOS
   end
 end


### PR DESCRIPTION
I don't know what happened exactly, but Goreleaser used the old template with `undent` for some reason :(
