### PR TITLE
Migrate to the new service brew syntax

### DIFF
--- a/stripe-mock.rb
+++ b/stripe-mock.rb
@@ -58,8 +58,6 @@ class StripeMock < Formula
       "12112"
     ]
     working_dir var
-    environment_variables PATH: HOMEBREW_PREFIX/"bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-    process_type :interactive
     log_path var/"log/stripe-mock.log"
     error_log_path var/"log/stripe-mock.log"
   end

--- a/stripe-mock.rb
+++ b/stripe-mock.rb
@@ -57,7 +57,7 @@ class StripeMock < Formula
       "-https-port",
       "12112"
     ]
-    run_type :immediate
+    run_at_load true
     working_dir var
     environment_variables PATH: HOMEBREW_PREFIX/"bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
     process_type :interactive

--- a/stripe-mock.rb
+++ b/stripe-mock.rb
@@ -47,37 +47,21 @@ class StripeMock < Formula
 
   plist_options :startup => false
 
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>KeepAlive</key>
-    <dict>
-      <key>SuccessfulExit</key>
-      <false/>
-    </dict>
-    <key>Label</key>
-    <string>#{plist_name}</string>
-    <key>ProgramArguments</key>
-    <array>
-      <string>#{opt_bin}/stripe-mock</string>
-      <string>-http-port</string>
-      <string>12111</string>
-      <string>-https-port</string>
-      <string>12112</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>WorkingDirectory</key>
-    <string>#{var}</string>
-    <key>StandardErrorPath</key>
-    <string>#{var}/log/stripe-mock.log</string>
-    <key>StandardOutPath</key>
-    <string>#{var}/log/stripe-mock.log</string>
-  </dict>
-</plist>
+  service do
+    keep_alive successful_exit: false
 
-  EOS
+    run [
+      opt_bin/"stripe-mock",
+      "-http-port", 
+      "12111",
+      "-https-port",
+      "12112"
+    ]
+    run_type :immediate
+    working_dir var
+    environment_variables PATH: HOMEBREW_PREFIX/"bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    process_type :interactive
+    log_path var/"log/stripe-mock.log"
+    error_log_path var/"log/stripe-mock.log"
   end
 end

--- a/stripe-mock.rb
+++ b/stripe-mock.rb
@@ -57,7 +57,6 @@ class StripeMock < Formula
       "-https-port",
       "12112"
     ]
-    run_at_load true
     working_dir var
     environment_variables PATH: HOMEBREW_PREFIX/"bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
     process_type :interactive

--- a/stripe-mock.rb
+++ b/stripe-mock.rb
@@ -45,8 +45,6 @@ class StripeMock < Formula
     end
   end
 
-  plist_options :startup => false
-
   service do
     keep_alive successful_exit: false
 


### PR DESCRIPTION
For the reference the conversion from new syntax to plist happens in https://github.com/Homebrew/brew/blob/master/Library/Homebrew/service.rb